### PR TITLE
Use constants for prerequisites

### DIFF
--- a/image/tutorial_app/tutorial_app/task_manager.py
+++ b/image/tutorial_app/tutorial_app/task_manager.py
@@ -3,10 +3,12 @@ from pathlib import Path
 import peewee
 from golem_task_api.apputils.task import database
 
+from .constants import DOCKER_IMAGE, VERSION
+
 
 PREREQUISITES = {
-    "image": 'golemfactory/tutorialapp',
-    "tag": "1.0",
+    "image": DOCKER_IMAGE,
+    "tag": VERSION,
 }
 
 


### PR DESCRIPTION
Found this bug while updating the docs with test / run instructions.

The image version for the provider was wrong, changed it to use the constants instead